### PR TITLE
Docks support multiple connections + Ping role refactor

### DIFF
--- a/commands/party/ping.js
+++ b/commands/party/ping.js
@@ -147,15 +147,15 @@ module.exports = {
 
     const message = await interaction.fetchReply();
 
-      if (!interaction.client.dockPingMessages) {
-        interaction.client.dockPingMessages = new Map();
+      if (!interaction.client.dockPingMetadata) {
+        interaction.client.dockPingMetadata = new Map();
       }
 
-      interaction.client.dockPingMessages.set(message.id, {
+      interaction.client.dockPingMetadata.set(message.id, {
         content: `${content}`,
       })
       setTimeout(() => {
-        interaction.client.dockPingMessages.delete(message.id);
+        interaction.client.dockPingMetadata.delete(message.id);
       }, 60 * 60 * 1000);
     
   },

--- a/commands/party/ping.js
+++ b/commands/party/ping.js
@@ -147,11 +147,6 @@ module.exports = {
 
     const message = await interaction.fetchReply();
 
-    const dockFollower = await interaction.client.modules.db.getDockFollowForChannel(interaction.channelId);
-    const dock = dockFollower
-      ? await interaction.client.modules.db.getDock(dockFollower.dockId)
-      : null;
-
       if (!interaction.client.dockPingMessages) {
         interaction.client.dockPingMessages = new Map();
       }

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -296,23 +296,11 @@ module.exports = {
           });
         }
 
+        // receiving channels can share docks, but source channels stay separate to avoid cross-publishing
         const docks = await interaction.client.modules.db.getDocksFromChannelId(channelId);
         if (docks.length > 0) {
           return interaction.reply({
             content: `<#${channelId}> is already the source channel for docks: ${docks.map((dock) => interaction.client.modules.escapeMarkdown(dock.name)).join(", ")}. Choose a channel that is not used by Docks yet.`,
-            flags: MessageFlags.Ephemeral,
-          });
-        }
-
-        const followerUsingChannel =
-          await interaction.client.modules.db.getDockFollowForChannel(channelId);
-        const channelBelongsToThisFollow =
-          followerUsingChannel?.dockId?.toString() === dockId &&
-          followerUsingChannel?.guildId === interaction.guildId;
-
-        if (followerUsingChannel && !channelBelongsToThisFollow) {
-          return interaction.reply({
-            content: `<#${channelId}> is already following docks. Choose a channel that is not following any docks yet`,
             flags: MessageFlags.Ephemeral,
           });
         }

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -6,9 +6,6 @@ const {
   MessageFlags,
   ChannelType,
   Events,
-  RoleSelectMenuBuilder,
-  ModalBuilder,
-  LabelBuilder,
 } = require("discord.js");
 const { ObjectId } = require("mongodb");
 
@@ -37,6 +34,7 @@ module.exports = {
     }
 
     if (interaction.isModalSubmit()) {
+      console.log(`[modal-submit] ${interaction.customId}`);
       let modalId;
       let dockId;
       let partyId;
@@ -160,6 +158,13 @@ module.exports = {
           ChannelType.GuildAnnouncement,
         ]);
 
+        if (keywords.length > 25) {
+          return interaction.reply({
+            content: "You can only have up to 25 keywords.",
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+
         const selectedChannels = Array.from(channels.values());
         const channelIds = selectedChannels.map((channel) => channel.id);
 
@@ -263,15 +268,21 @@ module.exports = {
       }
 
       [modalId, dockId] = interaction.customId.split(":");
-      if (modalId === "dock-follow-modal" || modalId === "dock-configure-follower-modal") {
-        const isConfiguringFollower = modalId === "dock-configure-follower-modal";
+      if (modalId === "dock-follow-modal" || modalId === "dock-configure-follower") {
+        const isConfiguringFollower = modalId === "dock-configure-follower";
         const channels = interaction.fields.getSelectedChannels("dock-follow-channel", true, [
           ChannelType.GuildText,
           ChannelType.GuildAnnouncement,
         ]);
         const [channelId] = channels.keys();
         const [channel] = channels.values();
-        const roles = interaction.fields.getSelectedRoles("dock-follow-ping-roles", false);
+        const hasKeywordField = interaction.fields.fields.has("keyword");
+        const keyword = hasKeywordField
+          ? interaction.fields.getStringSelectValues("keyword")[0]
+          : null;
+        const roles = hasKeywordField
+          ? interaction.fields.getSelectedRoles("roles", false)
+          : null;
         const roleIds = roles ? Array.from(roles.keys()) : [];
 
         if (!(await interaction.client.modules.dockBotPerms.check(interaction, channel))) {
@@ -281,6 +292,11 @@ module.exports = {
           dockId,
           interaction.guildId,
         );
+
+        const currentKeywordPings = Array.isArray(existingFollower?.keywordPings)
+          ? {}
+          : { ...(existingFollower?.keywordPings ?? {}) };
+        if (keyword) currentKeywordPings[keyword] = roleIds;
 
         if (!isConfiguringFollower && existingFollower) {
           return interaction.reply({
@@ -310,14 +326,15 @@ module.exports = {
           interaction.guildId,
           interaction.guild.name,
           [channelId],
-          roleIds,
+          currentKeywordPings,
         );
         const dock = await interaction.client.modules.db.getDock(dockId);
 
         interaction.reply({
-          content: isConfiguringFollower
-            ? `Updated Dock \`${dock.name}\` to post in <#${channelId}>.`
-            : `Followed Dock \`${dock.name}\` in <#${channelId}>.`,
+          content:
+            isConfiguringFollower
+              ? `Updated Dock \`${dock.name}\` to post in <#${channelId}>.`
+              : `Followed Dock \`${dock.name}\` in <#${channelId}>.`,
           flags: MessageFlags.Ephemeral,
         });
 
@@ -334,29 +351,40 @@ module.exports = {
 
       [modalId, dockId] = interaction.customId.split(":");
       if (modalId === "dock-home-ping-roles") {
-        const [, dockId] = interaction.customId.split(":");
         const dock = await interaction.client.modules.db.getDock(dockId);
 
-        if (!dock) return;
+        if (!dock || dock.guildId !== interaction.guildId) {
+          return interaction.reply({
+            content: "I couldn't find that Dock in this Discord server.",
+            flags: MessageFlags.Ephemeral,
+          });
+        }
 
         const selfFollow = await interaction.client.modules.db.getDockFollower(
           dockId,
           interaction.guildId,
         );
+        if (!selfFollow) return;
 
         const channelIds = selfFollow?.channelIds?.length ? selfFollow.channelIds : dock.channelIds;
-        const roles = interaction.fields.getSelectedRoles("dock-home-ping-roles", false);
+        const keyword = interaction.fields.getStringSelectValues("keyword")[0];
+        const roles = interaction.fields.getSelectedRoles("roles", false);
         const roleIds = roles ? Array.from(roles.keys()) : [];
+        const keywordPings = Array.isArray(selfFollow.keywordPings)
+          ? {}
+          : { ...(selfFollow.keywordPings ?? {}) };
+        keywordPings[keyword] = roleIds;
+
         await interaction.client.modules.db.setDockFollower(
           dockId,
           interaction.guildId,
           interaction.guild.name,
           channelIds,
-          roleIds,
+          keywordPings,
         );
 
         await interaction.reply({
-          content: `Updated Home Ping Roles for Dock \`${interaction.client.modules.escapeMarkdown(dock.name)}\` to ${roleIds.map((roleId) => `<@&${roleId}>`).join(", ")}.`,
+          content: `Updated \`${interaction.client.modules.escapeMarkdown(keyword)}\` Home Ping Roles for Dock \`${interaction.client.modules.escapeMarkdown(dock.name)}\` to ${roleIds.map((roleId) => `<@&${roleId}>`).join(", ") || "none"}.`,
           flags: MessageFlags.Ephemeral,
         });
       } 
@@ -608,7 +636,7 @@ module.exports = {
         return interaction.client.modules.dockFollowModal(
           interaction,
           dockId,
-          "dock-configure-follower-modal",
+          "dock-configure-follower",
           follower,
         );
       }
@@ -627,26 +655,18 @@ module.exports = {
           dockId,
           interaction.guildId,
         );
-
-        const roleSelect = new RoleSelectMenuBuilder()
-          .setCustomId("dock-home-ping-roles")
-          .setMaxValues(25)
-          .setRequired(false);
-
-        if (selfFollow?.pingRoleIds?.length) {
-          roleSelect.setDefaultRoles(selfFollow.pingRoleIds.slice(0, 25));
+        if (!dock.keywords?.some(Boolean)) {
+          return interaction.reply({
+            content: "Add ping keywords to this Dock before assigning Home Ping Roles.",
+            flags: MessageFlags.Ephemeral,
+          });
         }
 
-        return interaction.showModal(
-          new ModalBuilder()
-            .setTitle("Home Ping Roles")
-            .setCustomId(`dock-home-ping-roles:${dockId}`)
-            .addLabelComponents(
-              new LabelBuilder()
-                .setLabel("Home Ping Roles")
-                .setDescription("These roles will be pinged whenever a dock ping is recieved")
-                .setRoleSelectMenuComponent(roleSelect),
-            ),
+        return interaction.client.modules.dockFollowModal(
+          interaction,
+          dockId,
+          "dock-home-ping-roles",
+          selfFollow,
         );
       }
 

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -40,10 +40,12 @@ module.exports = {
     if (!message.guildId || !message.channel?.id) return;
     if (message.webhookId) return;
     if (message.client.dockRelayedPartyCardMessages?.has(message.id)) return;
+    const partyCardId = message.client.modules.dockRelay.getPartyIdFromComponents(message);
     if (
       message.author.id === message.client.user.id &&
-      ![MessageType.Default, MessageType.Reply].includes(message.type)
-    )
+      ![MessageType.Default, MessageType.Reply].includes(message.type) &&
+      !partyCardId
+    ) // ordinary bot interaction responses are ignored, but party cards are allowed
       return;
 
     try {
@@ -60,7 +62,6 @@ module.exports = {
       let messageToPublish = message;
       let publishOptions = {};
       let publishThis = Boolean(dock) && canPublishToDock && publishMode !== "manual";
-
       if (dock && canPublishToDock && publishMode === "manual" && /^!p(?:\s|$)/i.test((message.content ?? "").trim())) {
         const publishContent = (message.content ?? "").trim().slice(publishPrefix.length).trim();
         if (publishContent) { // The user typed text after !p
@@ -138,15 +139,12 @@ module.exports = {
       }
 
       if (publishThis && messageToPublish) {
-        const partyId = message.client.modules.dockRelay.getPartyIdFromComponents(messageToPublish);
-
+        const partyId = messageToPublish === message
+          ? partyCardId
+          : message.client.modules.dockRelay.getPartyIdFromComponents(messageToPublish);
         if (partyId) {
           const party = await message.client.modules.db.getParty(new ObjectId(partyId));
-          if (party?.visibility === "private") {
-            if (!(/^!p(?:\s|$)/i.test((message.content ?? "").trim()))) {
-              return;
-            }
-          }
+          if (party?.visibility === "private") return;
           if (party) {
             await message.client.modules.dockRelay.relayAlert({ // relay all party cards as alerts
               client: message.client,

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -49,42 +49,59 @@ module.exports = {
       return;
 
     try {
-      const dockFollower = await message.client.modules.db.getDockFollowForChannel(
-        message.channel.id,
-      );
-      const dock = dockFollower
-        ? await message.client.modules.db.getDock(dockFollower.dockId)
-        : null;
+      // a channel can be connected to multiple docks now, but only owners and contributors can publish
+      const dockConnections =
+        await message.client.modules.dockRelay.getWritableConnections(
+          message.client,
+          message.channel.id,
+          message.guildId,
+        );
       const settings = await message.client.modules.db.getSettings(message.guildId);
       const publishPrefix = "!p";
-      const publishMode = dock?.publishMode;
-      const canPublishToDock = dock?.guildId === message.guildId || dockFollower?.contributor === true;
-      let messageToPublish = message;
-      let publishOptions = {};
-      let publishThis = Boolean(dock) && canPublishToDock && publishMode !== "manual";
-      if (dock && canPublishToDock && publishMode === "manual" && /^!p(?:\s|$)/i.test((message.content ?? "").trim())) {
+      const isPublishCommand = /^!p(?:\s|$)/i.test((message.content ?? "").trim());
+      let manualSelection = null;
+      let manualPublishOptions = {};
+
+      // keep the !p selection separate because the same channel can have manual and automatic docks
+      if (isPublishCommand) {
         const publishContent = (message.content ?? "").trim().slice(publishPrefix.length).trim();
         if (publishContent) { // The user typed text after !p
-          publishOptions = { content: publishContent };
-          publishThis = true;
+          manualSelection = message;
+          manualPublishOptions = { content: publishContent };
         } else if (message.reference?.messageId) { // !p is replying to a message
-          messageToPublish = await message.channel.messages
+          manualSelection = await message.channel.messages
             .fetch(message.reference.messageId)
             .catch(() => null);
-          publishThis = Boolean(messageToPublish);
         }
       }
 
+      // decide what each dock gets before relaying so every dock can respect its own publish mode
+      const relayJobs = dockConnections
+        .map(({ dock, follower }) => ({
+          dock,
+          follower,
+          messageToPublish: dock.publishMode === "manual" ? manualSelection : message,
+          publishOptions: dock.publishMode === "manual" ? manualPublishOptions : {},
+        }))
+        .filter(({ messageToPublish }) => Boolean(messageToPublish));
+
       if (!(message.author.bot && message.author.id === message.client.user.id)) {
-        const keywordSource = getMessageText(messageToPublish) || getMessageText(message);
-        const includesKeyword = (keywords = []) =>
+        const keywordSource = getMessageText(manualSelection) || getMessageText(message);
+        const includesKeyword = (source, keywords = []) =>
           keywords.some((keyword) =>
-            keywordSource.toLowerCase().includes(keyword.toLowerCase().trim()),
+            source.toLowerCase().includes(keyword.toLowerCase().trim()),
           );
 
-        const dockKeywordMatched = includesKeyword(dock?.keywords ?? []);
+        // check each dock separately because docks sharing a channel can have different keywords
+        const matchingDockConnections = dockConnections.filter(({ dock }) => {
+          const source = dock.publishMode === "manual"
+            ? getMessageText(manualSelection)
+            : getMessageText(message);
+          return includesKeyword(source, dock.keywords ?? []);
+        });
+        const dockKeywordMatched = matchingDockConnections.length > 0;
         const matchedGroups = (settings.pingGroups ?? []).filter(
-          (group) => group.roleId && includesKeyword(group.keywords ?? []),
+          (group) => group.roleId && includesKeyword(keywordSource, group.keywords ?? []),
         );
 
         if (dockKeywordMatched || matchedGroups.length > 0) {
@@ -94,11 +111,14 @@ module.exports = {
           let pingMessage = null;
 
           if (dockKeywordMatched) {
-            roleIds = dockFollower?.pingRoleIds ?? [];
+            roleIds = [...new Set(
+              matchingDockConnections.flatMap(({ follower }) => follower.pingRoleIds ?? []),
+            )];
+            const dockNames = matchingDockConnections.map(({ dock }) => dock.name).join(", ");
             pingMessage = await message
               .reply({
                 content:
-                  `${roleIds.map((roleId) => `<@&${roleId}>`).join(" ")} ${dock?.name} ping triggered by <@${message.author.id}>!`.trim(),
+                  `${roleIds.map((roleId) => `<@&${roleId}>`).join(" ")} ${dockNames} ping triggered by <@${message.author.id}>!`.trim(),
                 allowedMentions: { roles: roleIds, repliedUser: false },
               })
               .catch((error) => {
@@ -120,17 +140,25 @@ module.exports = {
           }
           
 
-          if (dockKeywordMatched && pingMessage && messageToPublish) {
+          if (dockKeywordMatched && pingMessage) {
             if (!message.client.dockPingMessages) {
               message.client.dockPingMessages = new Map();
             }
 
-            message.client.dockPingMessages.set(messageToPublish.id, {
-              content: `${dock?.name} ping triggered by <@${message.author.id}>!`,
-            });
+            // relayMessage checks this map by message id when it adds follower ping roles
+            const publishedMessageIds = [
+              ...new Set(relayJobs.map(({ messageToPublish }) => messageToPublish.id)),
+            ];
+            for (const messageId of publishedMessageIds) {
+              message.client.dockPingMessages.set(messageId, {
+                content: `${matchingDockConnections.map(({ dock }) => dock.name).join(", ")} ping triggered by <@${message.author.id}>!`,
+              });
+            }
             setTimeout(
               () => {
-                message.client.dockPingMessages.delete(messageToPublish.id);
+                for (const messageId of publishedMessageIds) {
+                  message.client.dockPingMessages.delete(messageId);
+                }
               },
               60 * 60 * 1000,
             );
@@ -138,13 +166,14 @@ module.exports = {
         }
       }
 
-      if (publishThis && messageToPublish) {
+      // one discord message may need to be sent through more than one dock
+      for (const { dock, follower, messageToPublish, publishOptions } of relayJobs) {
         const partyId = messageToPublish === message
           ? partyCardId
           : message.client.modules.dockRelay.getPartyIdFromComponents(messageToPublish);
         if (partyId) {
           const party = await message.client.modules.db.getParty(new ObjectId(partyId));
-          if (party?.visibility === "private") return;
+          if (party?.visibility === "private") continue;
           if (party) {
             await message.client.modules.dockRelay.relayAlert({ // relay all party cards as alerts
               client: message.client,
@@ -156,7 +185,11 @@ module.exports = {
             });
           }
         } else {
-          await message.client.modules.dockRelay.relayMessage(messageToPublish, publishOptions);
+          await message.client.modules.dockRelay.relayMessage(
+            messageToPublish,
+            publishOptions,
+            follower,
+          );
         }
       }
 

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -45,17 +45,17 @@ module.exports = {
       message.author.id === message.client.user.id &&
       ![MessageType.Default, MessageType.Reply].includes(message.type) &&
       !partyCardId
-    ) // ordinary bot interaction responses are ignored, but party cards are allowed
+    )
+      // ordinary bot interaction responses are ignored, but party cards are allowed
       return;
 
     try {
       // a channel can be connected to multiple docks now, but only owners and contributors can publish
-      const dockConnections =
-        await message.client.modules.dockRelay.getWritableConnections(
-          message.client,
-          message.channel.id,
-          message.guildId,
-        );
+      const dockConnections = await message.client.modules.dockRelay.getWritableConnections(
+        message.client,
+        message.channel.id,
+        message.guildId,
+      );
       const settings = await message.client.modules.db.getSettings(message.guildId);
       const publishPrefix = "!p";
       const isPublishCommand = /^!p(?:\s|$)/i.test((message.content ?? "").trim());
@@ -65,10 +65,12 @@ module.exports = {
       // keep the !p selection separate because the same channel can have manual and automatic docks
       if (isPublishCommand) {
         const publishContent = (message.content ?? "").trim().slice(publishPrefix.length).trim();
-        if (publishContent) { // The user typed text after !p
+        if (publishContent) {
+          // The user typed text after !p
           manualSelection = message;
           manualPublishOptions = { content: publishContent };
-        } else if (message.reference?.messageId) { // !p is replying to a message
+        } else if (message.reference?.messageId) {
+          // !p is replying to a message
           manualSelection = await message.channel.messages
             .fetch(message.reference.messageId)
             .catch(() => null);
@@ -86,34 +88,48 @@ module.exports = {
         .filter(({ messageToPublish }) => Boolean(messageToPublish));
 
       if (!(message.author.bot && message.author.id === message.client.user.id)) {
-        const keywordSource = getMessageText(manualSelection) || getMessageText(message);
-        const includesKeyword = (source, keywords = []) =>
-          keywords.some((keyword) =>
-            source.toLowerCase().includes(keyword.toLowerCase().trim()),
-          );
+        const serverPingText = getMessageText(manualSelection) || getMessageText(message);
 
         // check each dock separately because docks sharing a channel can have different keywords
-        const matchingDockConnections = dockConnections.filter(({ dock }) => {
-          const source = dock.publishMode === "manual"
-            ? getMessageText(manualSelection)
-            : getMessageText(message);
-          return includesKeyword(source, dock.keywords ?? []);
-        });
-        const dockKeywordMatched = matchingDockConnections.length > 0;
+        const matchingDockConnections = dockConnections
+          .map(({ dock, follower }) => {
+            const dockMessageText =
+              dock.publishMode === "manual"
+                ? getMessageText(manualSelection)
+                : getMessageText(message);
+            const keyword = (dock.keywords ?? []).find((keyword) =>
+              dockMessageText.toLowerCase().includes(keyword.toLowerCase().trim()),
+            );
+            return {
+              dock,
+              follower,
+              keyword,
+            };
+          })
+          .filter(({ keyword }) => keyword);
+        const matchedKeywords = [...new Set(matchingDockConnections.map(({ keyword }) => keyword))];
         const matchedGroups = (settings.pingGroups ?? []).filter(
-          (group) => group.roleId && includesKeyword(keywordSource, group.keywords ?? []),
+          (group) =>
+            group.roleId &&
+            (group.keywords ?? []).some((keyword) =>
+              serverPingText.toLowerCase().includes(keyword.toLowerCase().trim()),
+            ),
         );
 
-        if (dockKeywordMatched || matchedGroups.length > 0) {
+        if (matchedKeywords.length > 0 || matchedGroups.length > 0) {
           let roleIds = [];
           const labels = matchedGroups.map((group) => group.name).filter(Boolean);
           const label = labels.length ? labels.join(", ") : "";
           let pingMessage = null;
 
-          if (dockKeywordMatched) {
-            roleIds = [...new Set(
-              matchingDockConnections.flatMap(({ follower }) => follower.pingRoleIds ?? []),
-            )];
+          if (matchedKeywords.length > 0) {
+            roleIds = [
+              ...new Set(
+                matchingDockConnections.flatMap(
+                  ({ follower, keyword }) => follower.keywordPings?.[keyword] ?? [],
+                ),
+              ),
+            ];
             const dockNames = matchingDockConnections.map(({ dock }) => dock.name).join(", ");
             pingMessage = await message
               .reply({
@@ -138,44 +154,47 @@ module.exports = {
                 return null;
               });
           }
-          
 
-          if (dockKeywordMatched && pingMessage) {
-            if (!message.client.dockPingMessages) {
-              message.client.dockPingMessages = new Map();
+          if (matchedKeywords.length > 0 && pingMessage) {
+            if (!message.client.dockPingMetadata) {
+              message.client.dockPingMetadata = new Map();
             }
 
             // relayMessage checks this map by message id when it adds follower ping roles
-            const publishedMessageIds = [
-              ...new Set(relayJobs.map(({ messageToPublish }) => messageToPublish.id)),
-            ];
-            for (const messageId of publishedMessageIds) {
-              message.client.dockPingMessages.set(messageId, {
-                content: `${matchingDockConnections.map(({ dock }) => dock.name).join(", ")} ping triggered by <@${message.author.id}>!`,
+            const messageIdToRelay = relayJobs[0]?.messageToPublish.id;
+
+            if (messageIdToRelay) {
+              message.client.dockPingMetadata.set(messageIdToRelay, {
+                username: message.author.username,
+                keywords: matchedKeywords,
               });
+
+              setTimeout(
+                () => {
+                  message.client.dockPingMetadata.delete(messageIdToRelay);
+                },
+                60 * 60 * 1000,
+              );
             }
-            setTimeout(
-              () => {
-                for (const messageId of publishedMessageIds) {
-                  message.client.dockPingMessages.delete(messageId);
-                }
-              },
-              60 * 60 * 1000,
-            );
           }
         }
       }
 
       // one discord message may need to be sent through more than one dock
       for (const { dock, follower, messageToPublish, publishOptions } of relayJobs) {
-        const partyId = messageToPublish === message
-          ? partyCardId
-          : message.client.modules.dockRelay.getPartyIdFromComponents(messageToPublish);
+        const partyId =
+          messageToPublish === message
+            ? partyCardId
+            : message.client.modules.dockRelay.getPartyIdFromComponents(messageToPublish);
+        if (message.author.id === message.client.user.id && !partyCardId) {
+          return;
+        }
         if (partyId) {
           const party = await message.client.modules.db.getParty(new ObjectId(partyId));
           if (party?.visibility === "private") continue;
           if (party) {
-            await message.client.modules.dockRelay.relayAlert({ // relay all party cards as alerts
+            await message.client.modules.dockRelay.relayAlert({
+              // relay all party cards as alerts
               client: message.client,
               dockId: dock._id,
               party,
@@ -192,7 +211,6 @@ module.exports = {
           );
         }
       }
-
     } catch (error) {
       console.error("[message-create] Failed to relay Dock message:", error);
     }

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -23,16 +23,16 @@ module.exports = {
         .catch(() => null);
       if (!webhook || webhook.channelId !== delivery.channelId) continue;
 
-      const pingRoleIds = delivery.pingRoleIds ?? [];
-      const content = pingRoleIds.length
-        ? `${pingRoleIds.map((roleId) => `<@&${roleId}>`).join(" ")}\n${message.content || ""}`
+      const keywordPings = delivery.keywordPings ?? [];
+      const content = keywordPings.length
+        ? `${keywordPings.map((roleId) => `<@&${roleId}>`).join(" ")}\n${message.content || ""}`
         : message.content || null;
 
       await webhook.editMessage(delivery.messageId, {
         content,
         embeds: message.embeds || [],
         attachments: message.attachments.map((attachment) => attachment.url) || [],
-        allowedMentions: { users: [message.author.id], roles: pingRoleIds },
+        allowedMentions: { users: [message.author.id], roles: keywordPings },
       });
     }
   },

--- a/events/threadCreate.js
+++ b/events/threadCreate.js
@@ -4,17 +4,16 @@ module.exports = {
   name: Events.ThreadCreate,
   async execute(thread) {
     try {
-      const dockFollower = await thread.client.modules.db.getDockFollowForChannel(
-        thread.parentId,
-      );
-      const dock = dockFollower
-        ? await thread.client.modules.db.getDock(dockFollower.dockId)
-        : null;
-
-      if (!dock) return;
-      if (dock.guildId !== dockFollower.guildId && dockFollower.contributor !== true) return;
+      // threads stay on one dock network even when the parent channel follows multiple docks
+      const [connection] =
+        await thread.client.modules.dockRelay.getWritableConnections(
+          thread.client,
+          thread.parentId,
+          thread.guildId,
+        );
+      if (!connection) return;
       
-      await thread.client.modules.dockRelay.relayThread(thread);
+      await thread.client.modules.dockRelay.relayThread(thread, connection.follower);
     } catch (error) {
       console.error("[thread-create] Failed to relay Dock thread:", error);
     }

--- a/src/modules/db.js
+++ b/src/modules/db.js
@@ -458,11 +458,11 @@ async function removeDock(dockId) {
   return dockFollowers.deleteMany({ dockId: new ObjectId(dockId) });
 }
 
-async function addDockFollower(dockId, guildId, guildName, channelIds = [], pingRoleIds = []) {
-  return setDockFollower(dockId, guildId, guildName, channelIds, pingRoleIds);
+async function addDockFollower(dockId, guildId, guildName, channelIds = [], keywordPings = {}) {
+  return setDockFollower(dockId, guildId, guildName, channelIds, keywordPings);
 }
 
-async function setDockFollower(dockId, guildId, guildName, channelIds = [], pingRoleIds = []) {
+async function setDockFollower(dockId, guildId, guildName, channelIds = [], keywordPings = {}) {
   const dockFollowers = getCollection("dockServers");
   const dockObjectId = new ObjectId(dockId);
   return dockFollowers.updateOne(
@@ -471,7 +471,7 @@ async function setDockFollower(dockId, guildId, guildName, channelIds = [], ping
       $set: {
         guildName,
         channelIds,
-        pingRoleIds,
+        keywordPings,
       },
       $setOnInsert: {
         dockId: dockObjectId,

--- a/src/modules/db.js
+++ b/src/modules/db.js
@@ -411,12 +411,7 @@ async function getManyDockFollowers(dockIds) {
   return dockFollowers.find({ dockId: { $in: dockIds } }).toArray();
 }
 
-async function getDockFollowForChannel(channelId) {
-  const dockFollowers = getCollection("dockServers");
-  return dockFollowers.findOne({ channelIds: channelId });
-}
-
-async function getDockFollowsForChannel(channelId) { // returns all the dock connections for that channel
+async function getDockFollowsForChannel(channelId) { // channels can follow multiple docks so this needs to return all matches
   const dockFollowers = getCollection("dockServers");
   return dockFollowers.find({ channelIds: channelId }).toArray();
 }
@@ -690,7 +685,6 @@ module.exports = {
   setDockWebhook,
   getDocksFromChannelId,
   getManyDockFollowers,
-  getDockFollowForChannel,
   getDockFollowsForChannel,
   getPublishedDocksForGuild,
   indexDockMessage,

--- a/src/modules/db.js
+++ b/src/modules/db.js
@@ -279,8 +279,6 @@ async function removeMembersFromParty(partyId, memberIds, interaction) {
   // Remove the member(s) by matching their id
 party.members = party.members.filter((m) => !memberIds.includes(m.id));
 
-  console.log(party.members); // should no longer include the removed member
-
   return await updateParty(party._id, { $set: { members: party.members } }, interaction);
 
 }

--- a/src/modules/deleteParty.js
+++ b/src/modules/deleteParty.js
@@ -32,7 +32,6 @@ module.exports = async function deleteParty(interaction, party) {
       });
     }
 
-    console.log(party);
 
     const deleteBtn = new ButtonBuilder()
       .setCustomId(`party-delete-confirm:${party._id}`)

--- a/src/modules/dockFollowModal.js
+++ b/src/modules/dockFollowModal.js
@@ -38,7 +38,7 @@ module.exports = async function dockFollowModal(
       .addLabelComponents(
         new LabelBuilder()
           .setLabel("Set receiving channel")
-          .setDescription("Select the channel to receive messages from this Dock")
+          .setDescription("A channel can receive messages from multiple Docks")
           .setChannelSelectMenuComponent(channelSelect),
       )
       .addLabelComponents(

--- a/src/modules/dockFollowModal.js
+++ b/src/modules/dockFollowModal.js
@@ -4,6 +4,7 @@ const {
   LabelBuilder,
   ModalBuilder,
   RoleSelectMenuBuilder,
+  StringSelectMenuBuilder,
 } = require("discord.js");
 
 module.exports = async function dockFollowModal(
@@ -12,40 +13,64 @@ module.exports = async function dockFollowModal(
   customId = "dock-follow-modal",
   defaults = {},
 ) {
+  const isHomePingRoles = customId === "dock-home-ping-roles";
   const channelSelect = new ChannelSelectMenuBuilder()
     .setCustomId("dock-follow-channel")
     .setChannelTypes([ChannelType.GuildText, ChannelType.GuildAnnouncement])
     .setMinValues(1)
     .setMaxValues(1);
 
+  const dock = await interaction.client.modules.db.getDock(dockId);
+  const keywords = [...new Set((dock?.keywords ?? []).filter(Boolean))].slice(0, 25);
+
+  const keywordSelect = keywords.length
+    ? new StringSelectMenuBuilder()
+        .setCustomId("keyword")
+        .setPlaceholder("Select a keyword")
+        .setMinValues(1)
+        .setMaxValues(1)
+        .addOptions(
+          keywords.map((keyword) => ({
+            label: keyword.slice(0, 100),
+            value: keyword.slice(0, 100),
+          })),
+        )
+    : null;
+  const roleSelect = new RoleSelectMenuBuilder()
+    .setCustomId("roles")
+    .setMaxValues(25)
+    .setRequired(false);
   if (defaults.channelIds?.length) {
     channelSelect.setDefaultChannels(defaults.channelIds.slice(0, 1));
   }
+  const modal = new ModalBuilder()
+    .setTitle(isHomePingRoles ? "Home Ping Roles" : "Dock Follow Settings")
+    .setCustomId(`${customId}:${dockId}`);
 
-  const roleSelect = new RoleSelectMenuBuilder()
-    .setCustomId("dock-follow-ping-roles")
-    .setMaxValues(25)
-    .setRequired(false);
-
-  if (defaults.pingRoleIds?.length) {
-    roleSelect.setDefaultRoles(defaults.pingRoleIds.slice(0, 25));
+  if (!isHomePingRoles) {
+    modal.addLabelComponents(
+      new LabelBuilder()
+        .setLabel("Set receiving channel")
+        .setDescription("A channel can receive messages from multiple Docks")
+        .setChannelSelectMenuComponent(channelSelect),
+    );
   }
 
-  return interaction.showModal(
-    new ModalBuilder()
-      .setTitle("Dock Follow Settings")
-      .setCustomId(`${customId}:${dockId}`)
+  if (keywordSelect) {
+    modal
       .addLabelComponents(
         new LabelBuilder()
-          .setLabel("Set receiving channel")
-          .setDescription("A channel can receive messages from multiple Docks")
-          .setChannelSelectMenuComponent(channelSelect),
+          .setLabel("Set keyword")
+          .setDescription("Choose a keyword to assign ping roles to")
+          .setStringSelectMenuComponent(keywordSelect),
       )
       .addLabelComponents(
         new LabelBuilder()
           .setLabel("Set ping roles")
-          .setDescription("These roles will be pinged whenever a party ping is recieved")
+          .setDescription("These roles will be pinged when the selected keyword is used")
           .setRoleSelectMenuComponent(roleSelect),
-      ),
-  );
+      );
+  }
+
+  return interaction.showModal(modal);
 };

--- a/src/modules/dockPublishModal.js
+++ b/src/modules/dockPublishModal.js
@@ -59,14 +59,14 @@ module.exports = async function dockPublishModal(
         new LabelBuilder()
           .setLabel("Ping Keywords")
           .setDescription(
-            "Whenever one of these keywords is included in a message, Dock followers will be pinged",
+            "Up to 25 keywords. Whenever a keyword is included in a message, Dock followers will be pinged",
           )
           .setTextInputComponent(
             new TextInputBuilder()
               .setCustomId("keywords")
               .setStyle(TextInputStyle.Paragraph)
               .setValue((defaults.keywords ?? []).join("\n"))
-              .setPlaceholder("Keyword 1\nKeyword 2\nKeyword 3")
+              .setPlaceholder("*Max 25 keywords.*\nKeyword 1\nKeyword 2\nKeyword 3")
               .setRequired(false)
               .setMaxLength(500),
           ),

--- a/src/modules/dockRelay.js
+++ b/src/modules/dockRelay.js
@@ -1,6 +1,4 @@
 const { MessageFlags } = require("discord.js");
-
-
 function getPartyIdFromComponents(message) {
   for (const row of message.components ?? []) {
     for (const component of row.components ?? []) {
@@ -267,8 +265,8 @@ async function relayMessage(message, options = {}, sendingFollower = null) {
     }))
     .filter((dockFollower) => dockFollower.channelIds.length > 0);
   if (receivingFollowers.length === 0) return;
-  const isDockPing = message.client.dockPingMessages?.has(message.id);
-  const dockPing = message.client.dockPingMessages?.get(message.id);
+  const isDockPing = message.client.dockPingMetadata?.has(message.id);
+  const dockPing = message.client.dockPingMetadata?.get(message.id);
 
   await message.client.modules.db.indexDockMessage({
     dockId: dock._id,
@@ -303,17 +301,25 @@ async function relayMessage(message, options = {}, sendingFollower = null) {
       };
       
       const relayedMessage = await webhook.send(messagePayload);
+      let pingRoles = [];
 
       if (isDockPing) {
-        const pingRoles = receivingFollower.pingRoleIds ?? [];
-        
+        pingRoles = [...new Set(
+          (dockPing.keywords ?? []).flatMap((keyword) =>
+            receivingFollower.keywordPings?.[keyword] ?? [],
+          ),
+        )];
+        const pingContent = `${dock.name} ping triggered by ${dockPing.username}>!`;
         messagePayload.content = pingRoles.length
-          ? `${pingRoles.map((roleId) => `<@&${roleId}>`).join(" ")}\n${dockPing.content}`
-          : dockPing.content;
+          ? `${pingRoles.map((roleId) => `<@&${roleId}>`).join(" ")} ${pingContent}`
+          : pingContent;
 
         messagePayload.allowedMentions.roles = pingRoles;
-
-        await webhook.send(messagePayload);
+        delete messagePayload.username;
+        delete messagePayload.avatarURL;
+        
+        const dockMessages = await 
+        await channel.send(messagePayload);
       }
 
       await message.client.modules.db.addDockMessageDeliveries(message.channel.id, message.id, [
@@ -322,7 +328,7 @@ async function relayMessage(message, options = {}, sendingFollower = null) {
           guildName: receivingFollower.guildName,
           channelId,
           messageId: relayedMessage.id,
-          pingRoleIds: isDockPing ? (receivingFollower.pingRoleIds ?? []) : [], 
+          keywordPings: pingRoles,
         },
       ]);
 
@@ -374,12 +380,7 @@ async function relayAlert({ client, dockId, ...payload }) {
         continue;
       }
 
-      const webhook = await getDockWebhook(client, channel, follower);
-      await webhook.send({
-        username: dock.name,
-        avatarURL: client.user.displayAvatarURL(),
-        ...payload,
-      });
+      await channel.send(payload);
     }
   }
 }

--- a/src/modules/dockRelay.js
+++ b/src/modules/dockRelay.js
@@ -17,6 +17,22 @@ function isPartyCard(message) {
   return Boolean(getPartyIdFromComponents(message));
 }
 
+async function getWritableConnections(client, channelId, guildId) {
+  // one channel can follow multiple docks, so return the docks as dock and its follower settings together
+  // each follower can have different contributor access, ping roles, and a guild name used in the relay label
+  const followers = await client.modules.db.getDockFollowsForChannel(channelId);
+  const connections = await Promise.all(
+    followers.map(async (follower) => ({
+      follower,
+      dock: await client.modules.db.getDock(follower.dockId),
+    })),
+  );
+
+  return connections.filter(
+    ({ dock, follower }) => dock && (dock.guildId === guildId || follower.contributor === true), // only writable connections are returned here or normal followers could publish back into a dock
+  );
+}
+
 async function getDockWebhook(client, channel, dockFollower) {
   const savedWebhook = await client.modules.db.getDockWebhook(dockFollower.guildId);
   if (savedWebhook?.webhookId) {
@@ -75,15 +91,21 @@ function getRelayFiles(message) {
   return attachments?.map((attachment) => attachment.url) ?? [];
 }
 
-async function relayThread(thread) {
+async function relayThread(thread, sendingFollower = null) {
   if (thread.name?.startsWith(RELAYED_THREAD_MARKER)) return;
 
   const existingDockThread = await thread.client.modules.db.getDockThread(thread.id);
   if (existingDockThread) return;
 
-  const sendingFollower = await thread.client.modules.db.getDockFollowForChannel(
-    thread.parentId,
-  );
+  if (!sendingFollower) {
+    // threads are indexed under one dock, so dont merge multiple dock thread networks together
+    const [connection] = await getWritableConnections(
+      thread.client,
+      thread.parentId,
+      thread.guildId,
+    );
+    sendingFollower = connection?.follower;
+  }
 
   const dock = await thread.client.modules.db.getDock(sendingFollower?.dockId);
   if (!dock) return;
@@ -219,12 +241,18 @@ async function relayThreadMessage(message) {
   }
 }
 
-async function relayMessage(message, options = {}) {
+async function relayMessage(message, options = {}, sendingFollower = null) {
   if (isPartyCard(message)) return;
 
-  const sendingFollower = await message.client.modules.db.getDockFollowForChannel(
-    message.channel.id,
-  );
+  if (!sendingFollower) {
+    // to get which docks we can write to, which docks we are contributors in
+    const [connection] = await getWritableConnections(
+      message.client,
+      message.channel.id,
+      message.guildId,
+    );
+    sendingFollower = connection?.follower;
+  }
 
   const dock = await message.client.modules.db.getDock(sendingFollower?.dockId);
   if (!dock) return;
@@ -374,6 +402,7 @@ async function dockRelay(input) {
 
 module.exports = {
   getPartyIdFromComponents,
+  getWritableConnections,
   relayAlert,
   relayMessage,
   relayThread,

--- a/src/modules/dockRelay.js
+++ b/src/modules/dockRelay.js
@@ -318,7 +318,6 @@ async function relayMessage(message, options = {}, sendingFollower = null) {
         delete messagePayload.username;
         delete messagePayload.avatarURL;
         
-        const dockMessages = await 
         await channel.send(messagePayload);
       }
 

--- a/src/modules/durationToMilliseconds.js
+++ b/src/modules/durationToMilliseconds.js
@@ -6,7 +6,6 @@ module.exports = (duration) => {
   const durationRegex = /(\d+)([smhd])/;
   const matches = duration.match(durationRegex);
 
-  console.log(duration);
   if (!matches) {
     throw new Error("Invalid duration format");
   }


### PR DESCRIPTION
- Refactor ping roles to be per-keyword, such as ping1 and ping2 for roleA
- Allow a channel to follow multiple docks 
  - ⚠️ If dock1 is in channel1, dock2 is also in channel1, and dock1 and dock2 both promote the Follower to a Contributor, all of the follower's messages will be forwarded to both docks. This may lead to confusion, and im trying to find a way to notify dock owners about this in the bot